### PR TITLE
Please include missing cdc_sump.h header in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+Picoprobe with the logic analyzer implementation based on the SUMP protocol
+===========================================================================
+
+Supported features:
+    
+- up to 16 probes (gpio 6-21 by default)
+- 200kB RAM for samples
+- RLE encoding
+- test mode (external pattern)
+  * probe 0 and 1 - 10Mhz PWM
+  * probe 1 and 2 - 1Mhz PWM
+  * probe 3 and 4 - 1kHz PWM
+  * probe 8 and 9 - 1kHz PWM (swapped levels)
+- test pin (gpio 22) - 5Mhz 50%/50% PWM for probe tests (activated only when sampling)
+    
+Limits:
+    
+- 50Mhz sampling rate when compiled with the TURBO_200MHZ define (otherwise 31.25Mhz)
+- basic triggers are implemented (functional up to 10Mhz - TODO: PIO support)
+    
+This protocol is supported in sigrok as openbench-logic-sniffer:
+    
+```
+  pulseview --driver=ols:conn=/dev/ttyACM1
+    
+  sigrok-cli --driver=ols:conn=/dev/ttyACM1 --config samplerate=50Mhz \
+             --config pattern=External --samples 256 --channels 0-1
+```
+
+Compile:
+
+```
+  mkdir build
+  cd build
+  TURBO_200MHZ=1 PICO_SDK_PATH=/opt/pico-sdk cmake ..
+```
+
+Compile RAM code (debug):
+
+```
+  mkdir build
+  cd build
+  TURBO_200MHZ=1 PICO_SDK_PATH=/opt/pico-sdk cmake -DPICO_NO_FLASH=1 -DCMAKE_BUILD_TYPE=Debug ..
+```
+    
+Misc:
+    
+- picoprobe reset pin is on gpio 28 (instead 6) now
+
+
+[Link to protocol](https://www.sump.org/projects/analyzer/protocol) | 
+[Link to libsigrok](https://github.com/sigrokproject/libsigrok/tree/master/src/hardware/openbench-logic-sniffer)

--- a/src/cdc_sump.h
+++ b/src/cdc_sump.h
@@ -1,0 +1,58 @@
+/*
+ * license header?
+ */
+
+#ifndef CDC_SUMP_H
+#define CDC_SUMP_H
+
+#define SUMP_META_NAME 1
+#define SUMP_META_FPGA_VERSION 2
+#define SUMP_META_CPU_VERSION 3
+#define SUMP_META_SAMPLE_RATE 0x23
+#define SUMP_META_SAMPLE_RAM 0x21/*?*/
+#define SUMP_META_PROBES_B 0x40/*?*/
+#define SUMP_META_PROTOCOL_B 0x24/*?*/
+#define SUMP_META_END 0
+
+#define SUMP_FLAG1_DDR 0/*TODO ???*/
+#define SUMP_FLAG1_GR0_DISABLE (1<<2)
+#define SUMP_FLAG1_GR1_DISABLE (1<<3)
+#define SUMP_FLAG1_GR2_DISABLE (1<<4)
+#define SUMP_FLAG1_GR3_DISABLE (1<<5)
+#define SUMP_FLAG1_EXT_TEST (1<<10)/*?*/
+#define SUMP_FLAG1_ENABLE_RLE (1<<8)/*?*/
+
+#define SUMP_CMD_RESET 0
+#define SUMP_CMD_ID 2
+#define SUMP_CMD_ARM 1
+#define SUMP_CMD_META 4
+#define SUMP_CMD_FINISH 5
+#define SUMP_CMD_QUERY_INPUT 6
+#define SUMP_CMD_ADVANCED_ARM 0xF
+#define SUMP_CMD_SET_SAMPLE_RATE 0x80/*?*/
+#define SUMP_CMD_SET_COUNTS 0x81/*?*/
+#define SUMP_CMD_SET_FLAGS 0x82
+#define SUMP_CMD_SET_ADV_TRG_SELECT 0x9E
+#define SUMP_CMD_SET_ADV_TRG_DATA 0x9F
+#define SUMP_CMD_SET_BTRG0_MASK 0xC0
+#define SUMP_CMD_SET_BTRG1_MASK 0xC4
+#define SUMP_CMD_SET_BTRG2_MASK 0xC8
+#define SUMP_CMD_SET_BTRG3_MASK 0xCC
+#define SUMP_CMD_SET_BTRG0_VALUE 0xC1
+#define SUMP_CMD_SET_BTRG1_VALUE 0xC5
+#define SUMP_CMD_SET_BTRG2_VALUE 0xC9
+#define SUMP_CMD_SET_BTRG3_VALUE 0xCD
+#define SUMP_CMD_SET_BTRG0_CONFIG 0xC2
+#define SUMP_CMD_SET_BTRG1_CONFIG 0xC6
+#define SUMP_CMD_SET_BTRG2_CONFIG 0xCA
+#define SUMP_CMD_SET_BTRG3_CONFIG 0xCE
+
+#define SUMP_CMD_IS_SHORT(x) 0/*TODO: ???*/
+
+void __isr sump_dma_irq_handler(void);
+void sump_rx(uint8_t *buf, uint count);
+void cdc_sump_init(void);
+void cdc_sump_task(void);
+void cdc_sump_line_coding(cdc_line_coding_t const *line_coding);
+
+#endif


### PR DESCRIPTION
I tried contacting you by email first, and as this repository doesn't have issues enabled, this will have to do.

The code isn't compileable as the `src/cdc_sump.h` file is missing:

```
picoprobe-sump/src/main.c:40:10: fatal error: cdc_sump.h: No such file or directory                                                                                                                                                                                    
   40 | #include "cdc_sump.h"                                                                                                                                                                                                                                          
      |          ^~~~~~~~~~~~                                                                                                                                                                                                                                          
compilation terminated.                                                                                                                                                                                                                                                
```

(You can ignore the actual code in the PR, don't merge this)